### PR TITLE
Add azuredevops to the default Azure provider generation

### DIFF
--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -68,8 +68,8 @@ define aws_provider
 provider \"aws\" {\n  region  = \"$(1)\"\n  profile = \"$(2)\"\n}\n
 endef
 
-define azurerm_provider
-provider \"azurerm\" {\n  skip_provider_registration = true\n  features {\n    resource_group {\n      prevent_deletion_if_contains_resources = false\n    }\n  }\n}\n
+define azure_provider
+provider \"azurerm\" {\n  skip_provider_registration = true\n  features {\n    resource_group {\n      prevent_deletion_if_contains_resources = false\n    }\n  }\n}\n\nprovider \"azuredevops\" {}\n
 endef
 
 define provider_file_path
@@ -79,7 +79,7 @@ endef
 define create_example_providers
 	$(eval PROVIDER_FILE_PATH:=$(call provider_file_path,$(1)))
 	$(if $(findstring aws,$(CURRENT_DIR)), [ -e $(PROVIDER_FILE_PATH) ] || bash -c 'echo -e "$(call aws_provider,$(AWS_REGION),$(AWS_PROFILE))"' > $(1)/provider.tf,)
-	$(if $(findstring azure,$(CURRENT_DIR)), [ -e $(PROVIDER_FILE_PATH) ] || bash -c 'echo -e "$(call azurerm_provider)"' > $(1)/provider.tf,)
+	$(if $(findstring azure,$(CURRENT_DIR)), [ -e $(PROVIDER_FILE_PATH) ] || bash -c 'echo -e "$(call azure_provider)"' > $(1)/provider.tf,)
 endef
 
 define plan_terraform_module


### PR DESCRIPTION
Adds the Azure DevOps provider configuration to our default Azure providers.

Like our existing AWS and Azure provider configurations, we won't be providing any direct configuration to the provider and will instead rely on developer machines and pipelines having the correct environment variables set for the provider to read.

See the following link for details on which environment variables need to be set:
https://github.com/microsoft/terraform-provider-azuredevops/blob/main/website/docs/index.html.markdown#authentication

I was able to get away with adding the following to my `~/.zshrc` for local purposes:

```sh
export AZDO_ORG_SERVICE_URL=https://dev.azure.com/Nexient-internal
export AZDO_PERSONAL_ACCESS_TOKEN=<PAT goes here>
```