### PR TITLE
Separate lint into lint + check

### DIFF
--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -178,6 +178,9 @@ tfmodule/create_example_providers:
 .PHONY: lint
 lint::
 	$(MAKE) tfmodule/lint
+
+.PHONY: check
+check::
 	$(MAKE) tfmodule/clone_custom_rules
 	$(MAKE) tfmodule/create_example_providers
 	$(MAKE) tfmodule/plan


### PR DESCRIPTION
Migrates subtargets that require cloud connectivity to the `make check` target. `make lint` should not require any sort of interaction with a cloud provider.

Technically, these rules don't require any sort of cloud connectivity, but they don't need to be run until we run `make check` so they're being moved as well:

```
tfmodule/clone_custom_rules
tfmodule/create_example_providers
```