### PR TITLE
Create global AWS provider alias

### DIFF
--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -65,7 +65,7 @@ define list_examples
 endef
 
 define aws_provider
-provider \"aws\" {\n  region  = \"$(1)\"\n  profile = \"$(2)\"\n}\n
+provider \"aws\" {\n  region  = \"$(1)\"\n  profile = \"$(2)\"\n}\n\nprovider \"aws\" {\n  alias   = \"global\"\n  region  = \"$(1)\"\n  profile = \"$(2)\"\n}\n
 endef
 
 define azurerm_provider


### PR DESCRIPTION
Adds a secondary provider (alias) that always points at us-east-1 for global services like CloudFront.

Use this in your TF modules like so:

```hcl
resource "aws_wafv2_web_acl" "global_acl" {
  provider = aws.global
  
  name     = var.name
  scope    = "CLOUDFRONT"
  ...
}
```