### PR TITLE
Account for tflint configuration file path in examples

### DIFF
--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -106,7 +106,7 @@ endef
 
 define tflint_terraform_module
 	echo && echo "Linting $(1) ...";
-	(cd $(1) && TF_LOG=info $(TFLINT) -c $(TFLINT_CONFIG)) || exit 1;
+	(cd $(1) && TF_LOG=info $(TFLINT) -c $(TFLINT_CONFIG) || TF_LOG=info $(TFLINT) -c ../../$(TFLINT_CONFIG)) || exit 1;
 
 endef
 


### PR DESCRIPTION
Load the tflint configuration file from the root of the repo if a failure occurs loading it from the current dir. This condition is hit every time we try to lint an example, and with later versions of `tflint` (> 0.48.0) this will cause nonzero exits.