### PR TITLE
Patch/linting and providers

### DIFF
--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -85,10 +85,10 @@ $(1)/provider.tf
 endef
 
 define add_provider_details
-	$(if $(findstring hashicorp/aws,$(2)),grep -q "aws" $(1) || bash -c 'echo -e "$(call aws_provider)"' >> $(1),)
-	$(if $(findstring azure/azapi,$(2)),grep -q "azapi" $(1) || bash -c 'echo -e "$(call azapi_provider)"' >> $(1),)
-	$(if $(findstring microsoft/azuredevops,$(2)),grep -q "azuredevops" $(1) || bash -c 'echo -e "$(call azuredevops_provider)"' >> $(1),)
-	$(if $(findstring hashicorp/azurerm,$(2)),grep -q "azurerm" $(1) || bash -c 'echo -e "$(call azurerm_provider)"' >> $(1),)
+	$(if $(findstring hashicorp/aws,$(2)),grep -qs "aws" $(1) || bash -c 'echo -e "$(call aws_provider)"' >> $(1),)
+	$(if $(findstring azure/azapi,$(2)),grep -qs "azapi" $(1) || bash -c 'echo -e "$(call azapi_provider)"' >> $(1),)
+	$(if $(findstring microsoft/azuredevops,$(2)),grep -qs "azuredevops" $(1) || bash -c 'echo -e "$(call azuredevops_provider)"' >> $(1),)
+	$(if $(findstring hashicorp/azurerm,$(2)),grep -qs "azurerm" $(1) || bash -c 'echo -e "$(call azurerm_provider)"' >> $(1),)
 endef
 
 define create_example_providers

--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -187,6 +187,7 @@ tfmodule/create_example_providers:
 
 .PHONY: lint
 lint::
+	$(MAKE) tfmodule/create_example_providers
 	$(MAKE) tfmodule/lint
 
 .PHONY: test


### PR DESCRIPTION
Fixes some minor issues with linting and providers.

First, creating example providers in a freshly-cloned repo would result in some error lines being logged by the Make target even though those errors were handled in code. Added the -s flag to `grep` to suppress these.

Next, modules that use an alias are failing linting because the global version of the provider can't be assumed by Terraform. Laying down the provider.tf files prior to `make lint` resolves this problem.