### PR TITLE
Only lay down provider.tf in the root module if there's a reference to an aws.global alias

### DIFF
--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -182,7 +182,7 @@ endif
 
 .PHONY: tfmodule/create_example_providers
 tfmodule/create_example_providers:
-	@$(call create_example_providers,.)
+	@$(if $(findstring aws.global,$(shell grep -se "\\s*provider\\s*=" *.tf || true)),$(call create_example_providers,.),)
 	@$(foreach example,$(ALL_EXAMPLES),$(call create_example_providers,$(example)))
 
 .PHONY: lint


### PR DESCRIPTION
This should resolve issues where linting examples complain about legacy modules with local provider configurations with an error message that looks like this:

> Initializing ./examples/zone-records ...
> Initializing modules...
> ╷
> │ Error: Module is incompatible with count, for_each, and depends_on
> │ 
> │   on main.tf line 27, in module "dns_record":
> │   27:   depends_on = [module.dns_zone]
> │ 
> │ The module at module.dns_record is a legacy module which contains its own local provider configurations, and so calls
> │ to it may not use the count, for_each, or depends_on arguments.
> │ 
> │ If you also control the module "../..", consider updating this module to instead expect provider configurations to be
> │ passed by its caller.
> ╵
> 
> make[2]: *** [tfmodule/init] Error 1
> make[1]: *** [test] Error 2
> make: *** [check] Error 2

If a root module contains "provider = aws.global" in any of its .tf files we'll lay the provider.tf file down in the root. Otherwise, we'll just lay provider.tf down for examples.