### PR TITLE
fix `make check` for fresh clones of reference modules

### DIFF
--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -181,7 +181,7 @@ else
 endif
 
 .PHONY: tfmodule/create_example_providers
-tfmodule/create_example_providers:
+tfmodule/create_example_providers : tfmodule/init
 	@$(if $(findstring aws.global,$(shell grep -se "\\s*provider\\s*=" *.tf || true)),$(call create_example_providers,.),)
 	@$(foreach example,$(ALL_EXAMPLES),$(call create_example_providers,$(example)))
 


### PR DESCRIPTION
the task `tfmodule/create_example_providers` makes use of the `terraform providers` command, which fails if the module has dependencies that have not yet been pulled in by `terraform init`

![image](https://github.com/user-attachments/assets/183ac0a6-cd9c-49c9-b0f3-057628172a80)

Consequently, on a fresh clone of reference / collection modules, `make check` will fail the first run due to missing provider configuration

![image](https://github.com/user-attachments/assets/4eb8349f-9e27-4e5e-8e60-abb3b1e4468e)

This change ensures `tfmodule/init` is ran before `tfmodule/create_example_providers`