### PR TITLE
Match golangci-lint hook version to .tool-versions from template repo

### DIFF
--- a/linkfiles/.pre-commit-config.yaml
+++ b/linkfiles/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
           - --hook-config=--create-file-if-not-exist=true
           - --args=--sort=false
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.55.2
+    rev: v1.63.4
     hooks:
       - id: golangci-lint
         name: golangci-lint


### PR DESCRIPTION
Match golangci-lint hook version to .tool-versions from template repo.

Will be released as `1.0.2`.