### PR TITLE
QOL fixes to Makefile (relative file calling and test.tfvars handling)

### DIFF
--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -98,7 +98,13 @@ endef
 
 define plan_terraform_module
 	echo && echo "Planning $(1) ...";
-	$(TERRAFORM) -chdir=$(1) plan -input=false -out=terraform.tfplan -var-file $(VAR_FILE);
+	if [ -f "$(1)/$(VAR_FILE)" ]; then \
+		echo "Using $(VAR_FILE) for variable inputs"; \
+		$(TERRAFORM) -chdir=$(1) plan -input=false -out=terraform.tfplan -var-file $(VAR_FILE); \
+	else \
+		echo "$(VAR_FILE) doesn't exist, falling back to default (terraform.tfvars)"; \
+		$(TERRAFORM) -chdir=$(1) plan -input=false -out=terraform.tfplan; \
+	fi;
 	echo && echo "Creating JSON plan output for $(1) ...";
 	cd $(1) && $(TERRAFORM) show -json ./terraform.tfplan > ./terraform.tfplan.json;
 

--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -106,7 +106,7 @@ endef
 
 define tflint_terraform_module
 	echo && echo "Linting $(1) ...";
-	(cd $(1) && TF_LOG=info $(TFLINT) -c $(TFLINT_CONFIG) || TF_LOG=info $(TFLINT) -c ../../$(TFLINT_CONFIG)) || exit 1;
+	(cd $(1) && TF_LOG=info $(TFLINT) -c $(PWD)/$(TFLINT_CONFIG)) || exit 1;
 
 endef
 


### PR DESCRIPTION
When running through some of the testing/migrating over a repo to utilize this I ran across a couple of small callouts that took me a bit off track:

1. When running tfmodule/lint I was getting errors as the tflint call had 2 assumed locations for the .tflint config file. Other scripting places this within the directory for the repo however either I am at a different depth than expected or there is some handler with the devcontainer that didnt work as expected. Simplifying the call for this the update simply makes it attempt to run from the relative called directory.

2. plan_terraform_module was attempting to use a test.tfvars file that wasnt present in the examples directories I was working with (which did have terraform.tfvars). Slight update to have an existence check ahead of utilizing the customized variable with fallback to default. (also outputs to console for debugging).

